### PR TITLE
Get rid of Override mess in both display sources

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Cake
+Copyright (c) 2026 Cake
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ minecraft_version=1.21.1
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[1.21.1]
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=21.1.200
+neo_version=21.1.217
 # The Neo version range can use any version of Neo as bounds
 neo_version_range=[21.1.200,)
 # The loader version range can only use the major version of FML as bounds
@@ -32,17 +32,17 @@ mod_id=trading_floor
 # The human-readable display name for the mod.
 mod_name=Create: Trading Floor
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
-mod_license=All Rights Reserved
+mod_license=MIT
 # The mod version. See https://semver.org/
 mod_version=3.0.14
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html
-mod_group_id=com.cak.trading_floor
+mod_group_id=com.cake.trading_floor
 # The authors of the mod. This is a simple text string that is used for display purposes in the mod list.
 mod_authors=Cake, Tazer
 # The description of the mod. This is a simple multiline text string that is used for display purposes in the mod list.
-mod_description=Automate trading with villagers in create!
+mod_description=Automate trading with villagers in Create!
 
 jei_version=19.21.0.247
 

--- a/src/main/java/com/cake/trading_floor/content/trading_depot/displays/CurrentTradeCompletedCountDisplaySource.java
+++ b/src/main/java/com/cake/trading_floor/content/trading_depot/displays/CurrentTradeCompletedCountDisplaySource.java
@@ -30,40 +30,18 @@ public class CurrentTradeCompletedCountDisplaySource extends SingleLineDisplaySo
     }
 
     @Override
+    protected String getTranslationKey() {
+        return "trade_completed_count";
+    }
+
+    @Override
     protected boolean allowsLabeling(DisplayLinkContext context) {
         return true;
     }
 
     @Override
-    @OnlyIn(Dist.CLIENT)
-    public void initConfigurationWidgets(DisplayLinkContext context, ModularGuiLineBuilder builder, boolean isFirstLine) {
-        if (isFirstLine && allowsLabeling(context))
-            addLabelingTextBox(builder);
+    protected String getFlapDisplayLayoutName(DisplayLinkContext context) {
+        return "Number";
     }
 
-    @OnlyIn(Dist.CLIENT)
-    protected void addLabelingTextBox(ModularGuiLineBuilder builder) {
-        builder.addTextInput(0, 137, (e, t) -> {
-            e.setValue("");
-            t.withTooltip(ImmutableList.of(CreateLang.translateDirect("display_source.label")
-                            .withStyle(s -> s.withColor(0x5391E1)),
-                    CreateLang.translateDirect("gui.schedule.lmb_edit")
-                            .withStyle(ChatFormatting.DARK_GRAY, ChatFormatting.ITALIC)));
-        }, "Label");
-    }
-
-    @Override
-    public List<List<MutableComponent>> provideFlapDisplayText(DisplayLinkContext context, DisplayTargetStats stats) {
-
-        if (allowsLabeling(context)) {
-            String label = context.sourceConfig()
-                    .getString("Label");
-            if (!label.isEmpty()) {
-                return ImmutableList.of(ImmutableList.of(Component.literal(label + " "), provideLine(context, stats)));
-            }
-        }
-
-        return super.provideFlapDisplayText(context, stats);
-    }
-    
 }

--- a/src/main/java/com/cake/trading_floor/content/trading_depot/displays/TradeProductSumDisplaySource.java
+++ b/src/main/java/com/cake/trading_floor/content/trading_depot/displays/TradeProductSumDisplaySource.java
@@ -33,39 +33,18 @@ public class TradeProductSumDisplaySource extends SingleLineDisplaySource {
     }
 
     @Override
+    protected String getTranslationKey() {
+        return "trade_product_sum";
+    }
+
+    @Override
     protected boolean allowsLabeling(DisplayLinkContext context) {
         return true;
     }
 
     @Override
-    @OnlyIn(Dist.CLIENT)
-    public void initConfigurationWidgets(DisplayLinkContext context, ModularGuiLineBuilder builder, boolean isFirstLine) {
-        if (isFirstLine && allowsLabeling(context))
-            addLabelingTextBox(builder);
+    protected String getFlapDisplayLayoutName(DisplayLinkContext context) {
+        return "Default";
     }
 
-    @OnlyIn(Dist.CLIENT)
-    protected void addLabelingTextBox(ModularGuiLineBuilder builder) {
-        builder.addTextInput(0, 137, (e, t) -> {
-            e.setValue("");
-            t.withTooltip(ImmutableList.of(CreateLang.translateDirect("display_source.label")
-                            .withStyle(s -> s.withColor(0x5391E1)),
-                    CreateLang.translateDirect("gui.schedule.lmb_edit")
-                            .withStyle(ChatFormatting.DARK_GRAY, ChatFormatting.ITALIC)));
-        }, "Label");
-    }
-
-    @Override
-    public List<List<MutableComponent>> provideFlapDisplayText(DisplayLinkContext context, DisplayTargetStats stats) {
-
-        if (allowsLabeling(context)) {
-            String label = context.sourceConfig()
-                    .getString("Label");
-            if (!label.isEmpty()) {
-                return ImmutableList.of(ImmutableList.of(Component.literal(label + " "), provideLine(context, stats)));
-            }
-        }
-
-        return super.provideFlapDisplayText(context, stats);
-    }
 }


### PR DESCRIPTION
- Gotten rid of the Override mess that I have previously created when [implementing the Attached Label option](https://github.com/cakeGit/Trading-Floor-Neoforge/pull/3) for both Display Sources present in Create: Trading Floor*;
- Fixed some Literally Unplayable™ issues in mod metadata that I couldn't help but fix myself immediately. >:P

###### *This comeback is totally, absolutely not in any way affiliated with me ending up coding an Attached Label enhancement add-on for Create that won't be able to impact those Display Sources in their current state :>